### PR TITLE
Fix `height` proptype definition

### DIFF
--- a/src/FadeIn.js
+++ b/src/FadeIn.js
@@ -48,7 +48,10 @@ class FadeIn extends React.Component {
     }
 }
 FadeIn.propTypes = {
-    height: PropTypes.number,
+    height:  PropTypes.oneOfType([
+        PropTypes.string,
+        PropTypes.number
+    ]),
     duration: PropTypes.number,
     easing: PropTypes.string,
     children: PropTypes.func,


### PR DESCRIPTION
Fix `height` props to be compatible with the `react-lazyload` props definition

See the `react-lazyloading` doc : https://github.com/jasonslyvia/react-lazyload#props